### PR TITLE
Fix crash when handling ValueTuples

### DIFF
--- a/ValveKeyValue/ValveKeyValue.Test/KVValueTupleTestCase.cs
+++ b/ValveKeyValue/ValveKeyValue.Test/KVValueTupleTestCase.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+
+namespace ValveKeyValue.Test
+{
+    class KVValueTupleTestCase
+    {
+        [Test]
+        public void SymmetricSerialization2Element()
+        {
+            var expected = ("hello", "world");
+
+            var serializer = KVSerializer.Create(KVSerializationFormat.KeyValues1Text);
+
+            using var ms = new MemoryStream();
+            serializer.Serialize(ms, expected, "root");
+            ms.Seek(0, SeekOrigin.Begin);
+            var actual = serializer.Deserialize<ValueTuple<string, string>>(ms);
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void SymmetricSerialization10Element()
+        {
+            var expected = ("hello", "world", "this", "is", "quite", "a", "long", "tuple", "isn't", "it?");
+
+            var serializer = KVSerializer.Create(KVSerializationFormat.KeyValues1Text);
+
+            using var ms = new MemoryStream();
+            serializer.Serialize(ms, expected, "root");
+            ms.Seek(0, SeekOrigin.Begin);
+            var actual = serializer.Deserialize<ValueTuple<string, string, string, string, string, string, string, ValueTuple<string, string, string>>>(ms);
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+    }
+}

--- a/ValveKeyValue/ValveKeyValue.Test/Test Data/Text/valuetuple10.vdf
+++ b/ValveKeyValue/ValveKeyValue.Test/Test Data/Text/valuetuple10.vdf
@@ -1,0 +1,16 @@
+"root"
+{
+	"Item1"	"1"
+	"Item2"	"2"
+	"Item3"	"3"
+	"Item4"	"4"
+	"Item5"	"5"
+	"Item6"	"6"
+	"Item7"	"7"
+	"Rest"
+	{
+		"Item1"	"8"
+		"Item2"	"9"
+		"Item3"	"10"
+	}
+}

--- a/ValveKeyValue/ValveKeyValue.Test/Test Data/Text/valuetuple2.vdf
+++ b/ValveKeyValue/ValveKeyValue.Test/Test Data/Text/valuetuple2.vdf
@@ -1,0 +1,5 @@
+"root"
+{
+	"Item1"	"hello"
+	"Item2"	"world"
+}

--- a/ValveKeyValue/ValveKeyValue.Test/Text/ValueTupleTextTestCase.cs
+++ b/ValveKeyValue/ValveKeyValue.Test/Text/ValueTupleTextTestCase.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using NUnit.Framework;
+
+namespace ValveKeyValue.Test
+{
+    class ValueTupleTextTestCase
+    {
+        [Test]
+        public void DeserializeValueTuple2Elements()
+        {
+            var vt = ("hello", "world");
+
+            using var stream = TestDataHelper.OpenResource("Text.valuetuple2.vdf");
+            var data = KVSerializer.Create(KVSerializationFormat.KeyValues1Text).Deserialize<ValueTuple<string, string>>(stream);
+
+            Assert.That(data, Is.EqualTo(vt));
+        }
+
+        [Test]
+        public void SerializeValueTuple2Elements()
+        {
+            var vt = ("hello", "world");
+
+            using var ms = new MemoryStream();
+            KVSerializer.Create(KVSerializationFormat.KeyValues1Text).Serialize(ms, vt, "root");
+
+            var text = Encoding.UTF8.GetString(ms.ToArray());
+            Assert.That(text, Is.EqualTo(TestDataHelper.ReadTextResource("Text.valuetuple2.vdf")));
+        }
+
+        [Test]
+        public void DeserializeValueTuple10Elements()
+        {
+            var vt = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+            using var stream = TestDataHelper.OpenResource("Text.valuetuple10.vdf");
+            var data = KVSerializer.Create(KVSerializationFormat.KeyValues1Text)
+                .Deserialize<ValueTuple<int, int, int, int, int, int, int, ValueTuple<int, int, int>>>(stream);
+
+            Assert.That(data, Is.EqualTo(vt));
+        }
+
+        [Test]
+        public void SerializeValueTuple10Elements()
+        {
+            var vt = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+            using var ms = new MemoryStream();
+            KVSerializer.Create(KVSerializationFormat.KeyValues1Text).Serialize(ms, vt, "root");
+
+            var text = Encoding.UTF8.GetString(ms.ToArray());
+            Assert.That(text, Is.EqualTo(TestDataHelper.ReadTextResource("Text.valuetuple10.vdf")));
+        }
+    }
+}

--- a/ValveKeyValue/ValveKeyValue/FieldMember.cs
+++ b/ValveKeyValue/ValveKeyValue/FieldMember.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Reflection;
+
+namespace ValveKeyValue
+{
+    sealed class FieldMember : IObjectMember
+    {
+        public FieldMember(FieldInfo fieldInfo, object @object)
+        {
+            Require.NotNull(fieldInfo, nameof(fieldInfo));
+            Require.NotNull(@object, nameof(@object));
+
+            this.fieldInfo = fieldInfo;
+            this.@object = @object;
+        }
+
+        readonly FieldInfo fieldInfo;
+        readonly object @object;
+
+        public bool IsExplicitName => false;
+
+        public string Name => fieldInfo.Name;
+
+        public Type MemberType => fieldInfo.FieldType;
+
+        public object Value
+        {
+            get => fieldInfo.GetValue(@object);
+            set => fieldInfo.SetValue(@object, value);
+        }
+    }
+}


### PR DESCRIPTION
This includes:
- Initial support for field serialization
- Initial support for struct serialization

Fixes #79.

This does not flatten the [Rest/TRest](https://learn.microsoft.com/en-us/dotnet/api/system.valuetuple-8.rest?view=net-7.0) property of large ValueTuples. I'm not sure yet if we should do that, or if we should purely represent the runtime layout of the object.

This also uses the "Item1"/"Item2"/... naming, not the modern C# aliases for the fields (e.g. `(hello: "world")`