### PR TITLE
Add `KVDocument` as a root type

### DIFF
--- a/ValveKeyValue/ValveKeyValue.Test/Test Data/apisurface.txt
+++ b/ValveKeyValue/ValveKeyValue.Test/Test Data/apisurface.txt
@@ -29,7 +29,7 @@ public class ValveKeyValue.KeyValueException
     public string ToString();
 }
 
-public class ValveKeyValue.KVFile
+public class ValveKeyValue.KVDocument
 {
     public void Add(ValveKeyValue.KVObject value);
     public bool Equals(object obj);
@@ -112,14 +112,14 @@ public sealed enum ValveKeyValue.KVSerializationFormat
 public class ValveKeyValue.KVSerializer
 {
     public static ValveKeyValue.KVSerializer Create(ValveKeyValue.KVSerializationFormat format);
-    public ValveKeyValue.KVFile Deserialize(System.IO.Stream stream, ValveKeyValue.KVSerializerOptions options);
+    public ValveKeyValue.KVDocument Deserialize(System.IO.Stream stream, ValveKeyValue.KVSerializerOptions options);
     public ValveKeyValue.TObject Deserialize<ValveKeyValue.TObject>(System.IO.Stream stream, ValveKeyValue.KVSerializerOptions options);
     public bool Equals(object obj);
     protected void Finalize();
     public int GetHashCode();
     public Type GetType();
     protected object MemberwiseClone();
-    public void Serialize(System.IO.Stream stream, ValveKeyValue.KVFile data, ValveKeyValue.KVSerializerOptions options);
+    public void Serialize(System.IO.Stream stream, ValveKeyValue.KVDocument data, ValveKeyValue.KVSerializerOptions options);
     public void Serialize(System.IO.Stream stream, ValveKeyValue.KVObject data, ValveKeyValue.KVSerializerOptions options);
     public void Serialize<ValveKeyValue.TData>(System.IO.Stream stream, ValveKeyValue.TData data, string name, ValveKeyValue.KVSerializerOptions options);
     public string ToString();

--- a/ValveKeyValue/ValveKeyValue.Test/Test Data/apisurface.txt
+++ b/ValveKeyValue/ValveKeyValue.Test/Test Data/apisurface.txt
@@ -119,6 +119,7 @@ public class ValveKeyValue.KVSerializer
     public int GetHashCode();
     public Type GetType();
     protected object MemberwiseClone();
+    public void Serialize(System.IO.Stream stream, ValveKeyValue.KVFile data, ValveKeyValue.KVSerializerOptions options);
     public void Serialize(System.IO.Stream stream, ValveKeyValue.KVObject data, ValveKeyValue.KVSerializerOptions options);
     public void Serialize<ValveKeyValue.TData>(System.IO.Stream stream, ValveKeyValue.TData data, string name, ValveKeyValue.KVSerializerOptions options);
     public string ToString();

--- a/ValveKeyValue/ValveKeyValue.Test/Test Data/apisurface.txt
+++ b/ValveKeyValue/ValveKeyValue.Test/Test Data/apisurface.txt
@@ -29,6 +29,23 @@ public class ValveKeyValue.KeyValueException
     public string ToString();
 }
 
+public class ValveKeyValue.KVFile
+{
+    public void Add(ValveKeyValue.KVObject value);
+    public bool Equals(object obj);
+    protected void Finalize();
+    public System.Collections.Generic.IEnumerable`1[[ValveKeyValue.KVObject]] get_Children();
+    public ValveKeyValue.KVValue get_Item(string key);
+    public string get_Name();
+    public ValveKeyValue.KVValue get_Value();
+    public System.Collections.Generic.IEnumerator`1[[ValveKeyValue.KVObject]] GetEnumerator();
+    public int GetHashCode();
+    public Type GetType();
+    protected object MemberwiseClone();
+    public void set_Item(string key, ValveKeyValue.KVValue value);
+    public string ToString();
+}
+
 public sealed class ValveKeyValue.KVIgnoreAttribute
 {
     public bool Equals(object obj);
@@ -95,7 +112,7 @@ public sealed enum ValveKeyValue.KVSerializationFormat
 public class ValveKeyValue.KVSerializer
 {
     public static ValveKeyValue.KVSerializer Create(ValveKeyValue.KVSerializationFormat format);
-    public ValveKeyValue.KVObject Deserialize(System.IO.Stream stream, ValveKeyValue.KVSerializerOptions options);
+    public ValveKeyValue.KVFile Deserialize(System.IO.Stream stream, ValveKeyValue.KVSerializerOptions options);
     public ValveKeyValue.TObject Deserialize<ValveKeyValue.TObject>(System.IO.Stream stream, ValveKeyValue.KVSerializerOptions options);
     public bool Equals(object obj);
     protected void Finalize();

--- a/ValveKeyValue/ValveKeyValue/KVDocument.cs
+++ b/ValveKeyValue/ValveKeyValue/KVDocument.cs
@@ -1,8 +1,8 @@
 namespace ValveKeyValue
 {
-    public class KVFile : KVObject
+    public class KVDocument : KVObject
     {
-        public KVFile(string name, KVValue value) : base(name, value)
+        public KVDocument(string name, KVValue value) : base(name, value)
         {
             // KV3 will require a header field that contains format/encoding here.
         }

--- a/ValveKeyValue/ValveKeyValue/KVFile.cs
+++ b/ValveKeyValue/ValveKeyValue/KVFile.cs
@@ -1,0 +1,10 @@
+namespace ValveKeyValue
+{
+    public class KVFile : KVObject
+    {
+        public KVFile(string name, KVValue value) : base(name, value)
+        {
+            // KV3 will require a header field that contains format/encoding here.
+        }
+    }
+}

--- a/ValveKeyValue/ValveKeyValue/KVSerializer.cs
+++ b/ValveKeyValue/ValveKeyValue/KVSerializer.cs
@@ -75,6 +75,15 @@ namespace ValveKeyValue
         }
 
         /// <summary>
+        /// Serializes a KeyValue object into stream.
+        /// </summary>
+        /// <param name="stream">The stream to serialize into.</param>
+        /// <param name="data">The data to serialize.</param>
+        /// <param name="options">Options to use that can influence the serialization process.</param>
+        public void Serialize(Stream stream, KVFile data, KVSerializerOptions options = null) =>
+            Serialize(stream, data, options);
+
+        /// <summary>
         /// Serializes a KeyValue object into stream in plain text..
         /// </summary>
         /// <param name="stream">The stream to serialize into.</param>

--- a/ValveKeyValue/ValveKeyValue/KVSerializer.cs
+++ b/ValveKeyValue/ValveKeyValue/KVSerializer.cs
@@ -30,8 +30,8 @@ namespace ValveKeyValue
         /// </summary>
         /// <param name="stream">The stream to deserialize from.</param>
         /// <param name="options">Options to use that can influence the deserialization process.</param>
-        /// <returns>A <see cref="KVObject"/> representing the KeyValues structure encoded in the stream.</returns>
-        public KVObject Deserialize(Stream stream, KVSerializerOptions options = null)
+        /// <returns>A <see cref="KVFile"/> representing the KeyValues structure encoded in the stream.</returns>
+        public KVFile Deserialize(Stream stream, KVSerializerOptions options = null)
         {
             Require.NotNull(stream, nameof(stream));
             var builder = new KVObjectBuilder();
@@ -41,7 +41,8 @@ namespace ValveKeyValue
                 reader.ReadObject();
             }
 
-            return builder.GetObject();
+            var root = builder.GetObject();
+            return new KVFile(root.Name, root.Value);
         }
 
         /// <summary>

--- a/ValveKeyValue/ValveKeyValue/KVSerializer.cs
+++ b/ValveKeyValue/ValveKeyValue/KVSerializer.cs
@@ -30,8 +30,8 @@ namespace ValveKeyValue
         /// </summary>
         /// <param name="stream">The stream to deserialize from.</param>
         /// <param name="options">Options to use that can influence the deserialization process.</param>
-        /// <returns>A <see cref="KVFile"/> representing the KeyValues structure encoded in the stream.</returns>
-        public KVFile Deserialize(Stream stream, KVSerializerOptions options = null)
+        /// <returns>A <see cref="KVDocument"/> representing the KeyValues structure encoded in the stream.</returns>
+        public KVDocument Deserialize(Stream stream, KVSerializerOptions options = null)
         {
             Require.NotNull(stream, nameof(stream));
             var builder = new KVObjectBuilder();
@@ -42,7 +42,7 @@ namespace ValveKeyValue
             }
 
             var root = builder.GetObject();
-            return new KVFile(root.Name, root.Value);
+            return new KVDocument(root.Name, root.Value);
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace ValveKeyValue
         /// <param name="stream">The stream to serialize into.</param>
         /// <param name="data">The data to serialize.</param>
         /// <param name="options">Options to use that can influence the serialization process.</param>
-        public void Serialize(Stream stream, KVFile data, KVSerializerOptions options = null) =>
+        public void Serialize(Stream stream, KVDocument data, KVSerializerOptions options = null) =>
             Serialize(stream, data, options);
 
         /// <summary>


### PR DESCRIPTION
I made it extend KVObject for backwards compatibility.

KV3 requires a special root object because it has a header that contains format and encoding data. KV2 might have some extra stuff too.

Perhaps there's a better way of doing this?

```csharp
    public class KVHeader
    {
        public Guid Encoding { get; set; }
        public Guid Format { get; set; }
    }
```

I think Serialize should have a new overload added to accept this, rather than changing the existing one because this would be a compat break. But how would this work with `Serialize<TData>`?
