### PR TITLE
Implement StringPool for binary kv1 used by Steam

### DIFF
--- a/ValveKeyValue/ValveKeyValue/Abstraction/IParsingVisitationListener.cs
+++ b/ValveKeyValue/ValveKeyValue/Abstraction/IParsingVisitationListener.cs
@@ -2,6 +2,8 @@ namespace ValveKeyValue.Abstraction
 {
     interface IParsingVisitationListener : IVisitationListener
     {
+        public string[] StringPool { get; set; }
+
         void DiscardCurrentObject();
 
         IParsingVisitationListener GetMergeListener();

--- a/ValveKeyValue/ValveKeyValue/Deserialization/KVObjectBuilder.cs
+++ b/ValveKeyValue/ValveKeyValue/Deserialization/KVObjectBuilder.cs
@@ -6,6 +6,8 @@ namespace ValveKeyValue.Deserialization
     {
         readonly IList<KVObjectBuilder> associatedBuilders = new List<KVObjectBuilder>();
 
+        public string[] StringPool { get; set; }
+
         public KVObject GetObject()
         {
             if (stateStack.Count != 1)

--- a/ValveKeyValue/ValveKeyValue/Deserialization/KeyValues1/KV1BinaryReader.cs
+++ b/ValveKeyValue/ValveKeyValue/Deserialization/KeyValues1/KV1BinaryReader.cs
@@ -8,7 +8,7 @@ namespace ValveKeyValue.Deserialization.KeyValues1
     {
         public const int BinaryMagicHeader = 0x564B4256; // VBKV
 
-        public KV1BinaryReader(Stream stream, IVisitationListener listener)
+        public KV1BinaryReader(Stream stream, IParsingVisitationListener listener)
         {
             Require.NotNull(stream, nameof(stream));
             Require.NotNull(listener, nameof(listener));
@@ -25,7 +25,7 @@ namespace ValveKeyValue.Deserialization.KeyValues1
 
         readonly Stream stream;
         readonly BinaryReader reader;
-        readonly IVisitationListener listener;
+        readonly IParsingVisitationListener listener;
         bool disposed;
         KV1BinaryNodeType endMarker = KV1BinaryNodeType.End;
 
@@ -76,8 +76,17 @@ namespace ValveKeyValue.Deserialization.KeyValues1
 
         void ReadValue(KV1BinaryNodeType type)
         {
-            var name = Encoding.UTF8.GetString(ReadNullTerminatedBytes());
+            string name;
             KVValue value;
+
+            if (listener.StringPool != null)
+            {
+                name = listener.StringPool[reader.ReadInt32()];
+            }
+            else
+            {
+                name = Encoding.UTF8.GetString(ReadNullTerminatedBytes());
+            }
 
             switch (type)
             {

--- a/ValveKeyValue/ValveKeyValue/KVSerializer.cs
+++ b/ValveKeyValue/ValveKeyValue/KVSerializer.cs
@@ -34,7 +34,10 @@ namespace ValveKeyValue
         public KVDocument Deserialize(Stream stream, KVSerializerOptions options = null)
         {
             Require.NotNull(stream, nameof(stream));
-            var builder = new KVObjectBuilder();
+            var builder = new KVObjectBuilder
+            {
+                StringPool = options?.StringPool
+            };
 
             using (var reader = MakeReader(stream, builder, options ?? KVSerializerOptions.DefaultOptions))
             {

--- a/ValveKeyValue/ValveKeyValue/KVSerializerOptions.cs
+++ b/ValveKeyValue/ValveKeyValue/KVSerializerOptions.cs
@@ -32,6 +32,11 @@ namespace ValveKeyValue
         /// </summary>
         public static KVSerializerOptions DefaultOptions => new();
 
+        /// <summary>
+        /// If KV1 is serialized using a string pool for the keys, provide the string pool here.
+        /// </summary>
+        public string[] StringPool;
+
         static IEnumerable<string> GetDefaultConditions()
         {
             // TODO: In the future we will want to skip this for consoles and mobile devices?


### PR DESCRIPTION
@yaakov-h how do we implement this sanely? They invented this and used by appinfo.vdf in Steam.

KV3 does the same thing, there's a string array for the keys. The only difference is that for kv1 they put the string pool separate from the KV1 data, so the parser can't parse it on its own.

Ref: https://github.com/SteamDatabase/SteamAppInfo/commit/56b1fec7f5ce6be961c3e44cf9baf117e363ad91#diff-97374b6129341b7a97d4a8056e32c8865a2553ad49aa9a70c841058fbccdfb2f