### PR TITLE
Target net8, add trimming support

### DIFF
--- a/ValveKeyValue/ValveKeyValue/DefaultObjectReflector.cs
+++ b/ValveKeyValue/ValveKeyValue/DefaultObjectReflector.cs
@@ -1,14 +1,14 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace ValveKeyValue
 {
     sealed class DefaultObjectReflector : IObjectReflector
     {
-        IEnumerable<IObjectMember> IObjectReflector.GetMembers(object @object)
+        IEnumerable<IObjectMember> IObjectReflector.GetMembers([DynamicallyAccessedMembers(Trimming.Properties)] Type objectType, object @object)
         {
+            Require.NotNull(objectType, nameof(objectType));
             Require.NotNull(@object, nameof(@object));
-
-            var objectType = @object.GetType();
 
             if (IsValueTupleType(objectType))
             {

--- a/ValveKeyValue/ValveKeyValue/FieldMember.cs
+++ b/ValveKeyValue/ValveKeyValue/FieldMember.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace ValveKeyValue
@@ -20,6 +21,8 @@ namespace ValveKeyValue
 
         public string Name => fieldInfo.Name;
 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2073", Justification = "FieldType")]
+        [DynamicallyAccessedMembers(Trimming.Properties)]
         public Type MemberType => fieldInfo.FieldType;
 
         public object Value

--- a/ValveKeyValue/ValveKeyValue/IObjectMember.cs
+++ b/ValveKeyValue/ValveKeyValue/IObjectMember.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace ValveKeyValue
 {
     interface IObjectMember
@@ -6,6 +8,7 @@ namespace ValveKeyValue
 
         string Name { get; }
 
+        [DynamicallyAccessedMembers(Trimming.Properties)]
         Type MemberType { get; }
 
         object Value { get; set; }

--- a/ValveKeyValue/ValveKeyValue/IObjectReflector.cs
+++ b/ValveKeyValue/ValveKeyValue/IObjectReflector.cs
@@ -1,7 +1,9 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace ValveKeyValue
 {
     interface IObjectReflector
     {
-        IEnumerable<IObjectMember> GetMembers(object @object);
+        IEnumerable<IObjectMember> GetMembers([DynamicallyAccessedMembers(Trimming.Properties)] Type objectType, object @object);
     }
 }

--- a/ValveKeyValue/ValveKeyValue/KVSerializer.cs
+++ b/ValveKeyValue/ValveKeyValue/KVSerializer.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using ValveKeyValue.Abstraction;
 using ValveKeyValue.Deserialization;
 using ValveKeyValue.Deserialization.KeyValues1;
@@ -52,7 +53,7 @@ namespace ValveKeyValue
         /// <param name="options">Options to use that can influence the deserialization process.</param>
         /// <returns>A <typeparamref name="TObject" /> instance representing the KeyValues structure in the stream.</returns>
         /// <typeparam name="TObject">The type of object to deserialize.</typeparam>;
-        public TObject Deserialize<TObject>(Stream stream, KVSerializerOptions options = null)
+        public TObject Deserialize<[DynamicallyAccessedMembers(Trimming.Constructors | Trimming.Properties)] TObject>(Stream stream, KVSerializerOptions options = null)
         {
             Require.NotNull(stream, nameof(stream));
 
@@ -91,7 +92,7 @@ namespace ValveKeyValue
         /// <param name="name">The top-level object name</param>
         /// <param name="options">Options to use that can influence the serialization process.</param>
         /// <typeparam name="TData">The type of object to serialize.</typeparam>
-        public void Serialize<TData>(Stream stream, TData data, string name, KVSerializerOptions options = null)
+        public void Serialize<[DynamicallyAccessedMembers(Trimming.Properties)] TData>(Stream stream, TData data, string name, KVSerializerOptions options = null)
         {
             Require.NotNull(stream, nameof(stream));
 

--- a/ValveKeyValue/ValveKeyValue/PropertyMember.cs
+++ b/ValveKeyValue/ValveKeyValue/PropertyMember.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace ValveKeyValue
@@ -21,6 +22,8 @@ namespace ValveKeyValue
         string IObjectMember.Name
             => PropertyAttribute?.PropertyName ?? propertyInfo.Name;
 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2073", Justification = "PropertyType")]
+        [DynamicallyAccessedMembers(Trimming.Properties)]
         Type IObjectMember.MemberType => propertyInfo.PropertyType;
 
         object IObjectMember.Value

--- a/ValveKeyValue/ValveKeyValue/Trimming.cs
+++ b/ValveKeyValue/ValveKeyValue/Trimming.cs
@@ -1,0 +1,17 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace ValveKeyValue
+{
+    internal static class Trimming
+    {
+        public const DynamicallyAccessedMemberTypes Constructors =
+            DynamicallyAccessedMemberTypes.PublicParameterlessConstructor |
+            DynamicallyAccessedMemberTypes.PublicConstructors |
+            DynamicallyAccessedMemberTypes.NonPublicConstructors;
+
+        public const DynamicallyAccessedMemberTypes Properties =
+            DynamicallyAccessedMemberTypes.PublicProperties |
+            DynamicallyAccessedMemberTypes.NonPublicProperties |
+            DynamicallyAccessedMemberTypes.PublicFields;
+    }
+}

--- a/ValveKeyValue/ValveKeyValue/ValveKeyValue.csproj
+++ b/ValveKeyValue/ValveKeyValue/ValveKeyValue.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
     <Product>Valve KeyValue Library</Product>
     <Description>Library to parse and write Valve KeyValue formats</Description>
@@ -10,6 +10,7 @@
     <PackageTags>steam valve keyvalues keyvalue kv kv3 csgo dota2 tf2</PackageTags>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>ValveKeyValue.snk</AssemblyOriginatorKeyFile>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\"/>


### PR DESCRIPTION
Continuation of #40, it seems to be slightly better, but still fundamentally has to suppress some messages because of `InvokeGeneric` design.

.NET9 has `Array.CreateInstanceFromArrayType` we could use as well.

~~EDIT: Okay, targeting net9 introduces new trimming errors...~~

I have also tried to publish an AOT build of ValveResourceFormat cli, and it didn't produce trimmer warnings for VKV.