### PR TITLE
Make `KVConditionEvaluator` non dynamic

### DIFF
--- a/ValveKeyValue/ValveKeyValue/KVConditionEvaluator.cs
+++ b/ValveKeyValue/ValveKeyValue/KVConditionEvaluator.cs
@@ -38,7 +38,7 @@ namespace ValveKeyValue
                 throw new InvalidDataException($"Invalid conditional syntax \"{expressionText}\"", ex);
             }
 
-            var value = (bool)Expression.Lambda(expression).Compile().DynamicInvoke();
+            var value = Expression.Lambda<Func<bool>>(expression).Compile().Invoke();
             return value;
         }
 


### PR DESCRIPTION
Cherry-picked from #111, as this causes a trimmer warning in .NET 9, but a typed version of this method exists in netstandard.

